### PR TITLE
Tentative fix for leaflet attributiions appearing in Google search results

### DIFF
--- a/src/leaflet/constants.js
+++ b/src/leaflet/constants.js
@@ -1,0 +1,7 @@
+export const attribution = 'Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community'
+
+export const dataSet = {
+  name: 'Place names in Norwegian polar areas',
+  url: 'https://doi.org/10.21334/npolar.2011.a2813eb6',
+}
+export const institute = 'Norwegian Polar Institute'

--- a/src/leaflet/leaflet-element.js
+++ b/src/leaflet/leaflet-element.js
@@ -3,7 +3,9 @@ import {
   TileLayer,
 } from "leaflet/dist/leaflet-src.esm.js";
 
-import { dataSet, institute } from './constants.js';
+import { dataSet } from './constants.js';
+
+import { get as t } from '../translate/exports.js';
 
 const eventFactory = (name, detail) =>
   new CustomEvent(name, { detail, bubbles: true, composed: true });
@@ -33,7 +35,7 @@ export class LeafletElement extends HTMLElement {
     this
       .map
       .attributionControl
-      .setPrefix(`<a href="${dataSet.url}">${dataSet.name}</a> (${institute})`)
+      .setPrefix(`<a href="${dataSet.url}">${t('site.name')}</a> (${t('site.org')})`)
     return this.map;
   }
 

--- a/src/leaflet/leaflet-element.js
+++ b/src/leaflet/leaflet-element.js
@@ -3,6 +3,8 @@ import {
   TileLayer,
 } from "leaflet/dist/leaflet-src.esm.js";
 
+import { dataSet, institute } from './constants.js';
+
 const eventFactory = (name, detail) =>
   new CustomEvent(name, { detail, bubbles: true, composed: true });
 
@@ -28,6 +30,10 @@ export class LeafletElement extends HTMLElement {
       layers,
     };
     this.map = new LeafletMapClass(elmt, config);
+    this
+      .map
+      .attributionControl
+      .setPrefix(`<a href="${dataSet.url}">${dataSet.name}</a> (${institute})`)
     return this.map;
   }
 

--- a/src/leaflet/world-imagery-map.js
+++ b/src/leaflet/world-imagery-map.js
@@ -1,7 +1,5 @@
 import { LeafletElement } from "./leaflet-element.js";
-
-const attribution =
-  "Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community";
+import { attribution } from './constants.js';
 
 const minZoom = 0;
 

--- a/src/translate/nn.js
+++ b/src/translate/nn.js
@@ -75,6 +75,7 @@ export default {
   meeting: {
     number: "møtenummer",
   },
+  site,
   "placenames-shell": { name, heading, site },
   "placenames-search": {
     heading: "Polare stadnamn",


### PR DESCRIPTION
The problem is as follows: when a placename does not have a lot of descriptive text, Google results will display the attribution of the leaflet map as an excerpt; it can lead the reader to think that the entities listed there are attributed for the placename itself (when they are attributed only for the cartography). This is misleading and should be rectified.

This PR just replaces the "leaflet" link that appear before the attributions by a link to the data set of placenames at data.npolar.no with an explicit mention of "Norwegian Polar Instititute". Hopefully, it will be enough (we will only see it once in production and reindexed by Google)

Ideally, one would just want to hide the text of the LeafletElement from Google indexing, as it is higly irrelevant to the actual content of the webpage. But this seems hard without relying on hacks such as image/svg embedding.