### PR TITLE
Fix filtering issue with case tab

### DIFF
--- a/src/case/routes.js
+++ b/src/case/routes.js
@@ -1,4 +1,5 @@
 import "../cases-search/cases-search.js";
+import { CasesSearch } from "../cases-search/cases-search.js";
 import "../case-article/case-article.js";
 import "../case-edit/case-edit.js";
 
@@ -19,7 +20,8 @@ const routes = (base) => [
   },
   {
     path: `${base}`,
-    component: "cases-search",
+    action: () => new CasesSearch(),
+    // @todo should be investigate further
   },
   {
     path: `${base}/(.*)`,

--- a/src/cases-search/cases-search-url.js
+++ b/src/cases-search/cases-search-url.js
@@ -40,6 +40,6 @@ export const casesSearchURL = ({
   }
 
   v2params.set("hide", "text,comment,created,updated,editor,version");
-  // v2params.set("facet", "area"); FIXME Faceting does not work!?
+  v2params.set("facet", "area"); 
   return v2url.href;
 };


### PR DESCRIPTION
Related to vaadin router and how it handles `component` vs `action`